### PR TITLE
Add per dimension overrides (headers) and overlays

### DIFF
--- a/src/main/java/net/werdei/biome_replacer/config/Config.java
+++ b/src/main/java/net/werdei/biome_replacer/config/Config.java
@@ -24,6 +24,7 @@ public class Config
         {
             rules.clear();
             var lineCount = 0;
+            String currentHeader = null; // null header means global (applies to all dimensions)
             while (reader.hasNextLine())
             {
                 var line = reader.nextLine().trim();
@@ -33,6 +34,17 @@ public class Config
                 if (line.isEmpty() || line.startsWith("!") || line.startsWith("# "))
                     continue;
                 
+                // Headers: [namespace:path]. [null] or [] are treated as global
+                if (line.startsWith("[") && line.endsWith("]"))
+                {
+                    var headerContent = line.substring(1, line.length() - 1).trim();
+                    if (headerContent.isEmpty() || headerContent.equalsIgnoreCase("null"))
+                        currentHeader = null;
+                    else
+                        currentHeader = headerContent;
+                    continue;
+                }
+
                 // Options. Might be used later.
                 if (line.contains("="))
                     continue;
@@ -61,7 +73,7 @@ public class Config
 //                    logRuleIssue(lineCount, "Unexpected number format. If you wanted to add probability, make sure it's a valid number");
                 }
                 
-                rules.add(new Rule(lineCount, oldBiome, newBiome, probability));
+                rules.add(new Rule(lineCount, oldBiome, newBiome, probability, currentHeader));
             }
         }
         catch (IOException e)
@@ -78,11 +90,25 @@ public class Config
 
         try (PrintWriter writer = new PrintWriter(file))
         {
-            writer.println("! Put your rules here in the format:");
-            writer.println("! old_biome > new_biome");
-            writer.println("! ");
-            writer.println("! Examples (remove ! in front of one to activate it):");
-            writer.println("! minecraft:dark_forest > minecraft:cherry_grove");
+            writer.println("! Biome Replacer configuration");
+            writer.println("! Format: old_biome > new_biome");
+            writer.println("!");
+            writer.println("! Rules before headers are applied to all worlds (dimensions)");
+            writer.println("! Remove the leading '!' to activate examples below.");
+            writer.println("!");
+            writer.println("! Global rules (apply to every dimension):");
+            writer.println("! minecraft:forest > minecraft:tundra");
+            writer.println("!");
+            writer.println("! Rules under a header apply only to the world (dimension) in brackets");
+            writer.println("! [minecraft:overworld]");
+            writer.println("! minecraft:desert > null");
+            writer.println("!");
+            writer.println("! [custom:dimension]");
+            writer.println("! minecraft:desert > minecraft:badlands");
+            writer.println("!");
+            writer.println("! Special headers: [null] or [] are treated as global (all dimensions)");
+            writer.println("!");
+            writer.println("! Tag examples (direct replacements have priority over tags):");
             writer.println("! #minecraft:is_forest > minecraft:desert");
             writer.println("! #terralith:skylands > null");
         }
@@ -94,7 +120,7 @@ public class Config
     }
     
     
-    public record Rule(int line, String from, String to, double probability)
+    public record Rule(int line, String from, String to, double probability, String dimension)
     {
         public Rule {
             probability = Math.max(0.0, Math.min(1.0, probability));

--- a/src/main/java/net/werdei/biome_replacer/replacer/VanillaReplacer.java
+++ b/src/main/java/net/werdei/biome_replacer/replacer/VanillaReplacer.java
@@ -92,7 +92,7 @@ public class VanillaReplacer
             }
             for (var value : parameters.values())
             {
-                var newBiome = replaceFromMap(value.getSecond(), effectiveRules);
+                var newBiome = applyRules(value.getSecond(), effectiveRules);
                 if (newBiome == null) continue;
                 newParameterList.add(new Pair<>(value.getFirst(), newBiome));
             }
@@ -188,10 +188,24 @@ public class VanillaReplacer
     
     public static Holder<Biome> replaceIfNeeded(Holder<Biome> original)
     {
-        return replacementRules.getOrDefault(original, original);
+        return applyRules(original, replacementRules);
+    }
+
+    public static Holder<Biome> replaceIfNeeded(Holder<Biome> original, String dimensionId)
+    {
+        var result = applyRules(original, replacementRules);
+
+        if (dimensionId != null && dimensionReplacementRules != null && !dimensionReplacementRules.isEmpty())
+        {
+            var dimensionRules = dimensionReplacementRules.get(dimensionId);
+            if (dimensionRules != null)
+                result = applyRules(result, dimensionRules);
+        }
+
+        return result;
     }
     
-    private static Holder<Biome> replaceFromMap(Holder<Biome> original, Map<Holder<Biome>, Holder<Biome>> rules)
+    private static Holder<Biome> applyRules(Holder<Biome> original, Map<Holder<Biome>, Holder<Biome>> rules)
     {
         if (rules == null || rules.isEmpty()) return original;
         return rules.getOrDefault(original, original);


### PR DESCRIPTION
#56

Per dimension overrides work for worldgen in TB dimensions that use NoiseBasedChunkGenerator + MultiNoiseBiomeSource (overrides are applied at LevelStem). The “possible biomes” / locate view remains global-only because TB doesn’t expose dimension context there (or for atleast what I saw). 

Tested on 1.21.1 Neoforge with vanilla datapack dimensions.

**This is the levels of control**  
```Per dimension > Global```
```Direct biome rules > Tag rules```  
_(later lines override earlier ones if it’s the same rule)_

I also updated the config to show these new features, albeit it's a bit wordy atm.