### PR TITLE
Support Minecraft 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ stonecutter {
 	constants["neoforge"] = loader.isNeoforge
 	constants["oldforge"] = loader.isOldforge
 	constants["forge-like"] = loader.isForgeLike
+	constants["unobfuscated"] = false
 
     // 1.21.11 "ResourceLocation" rename
     replacements.string(current.parsed >= "1.21.11") {
@@ -151,6 +152,7 @@ tasks.processResources {
 		put("name", mod.name)
 		put("version", mod.versionWithCodename)
 		put("minecraft", mc.dep)
+		put("fabricLoader", ">=0.16")
 		put("description", mod.description)
 		put("source", mod.source)
 		put("issues", mod.issues)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 }
 
 plugins {
-	id("dev.kikugie.stonecutter") version "0.8.2"
+	id("dev.kikugie.stonecutter") version "0.9.5"
 }
 
 stonecutter {
@@ -47,6 +47,11 @@ stonecutter {
         // Codename Pinkeen
         // Works on 1.21.11, needed because of a "ResourceLocation" rename (mysteriously, does not affect Fabric)
 		add("1.21.11", "neoforge")
+
+		// Codename Newt
+		// Works across 26.1 - 26.1.2
+		version("26.1.2-fabric", "26.1.2").buildscript("unobfuscated.gradle.kts")
+		version("26.1.2-neoforge", "26.1.2").buildscript("unobfuscated.gradle.kts")
 
 		vcsVersion = "1.21.4-fabric"
 	}

--- a/src/main/java/net/werdei/biome_replacer/BiomeReplacer.java
+++ b/src/main/java/net/werdei/biome_replacer/BiomeReplacer.java
@@ -6,6 +6,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.werdei.biome_replacer.config.Config;
+import net.werdei.biome_replacer.replacer.BlueprintReplacer;
 import net.werdei.biome_replacer.replacer.VanillaReplacer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,6 +32,7 @@ public class BiomeReplacer
     public static void doReplacement(Registry<Biome> biomeRegistry, Registry<LevelStem> stemRegistry)
     {
         Config.reload();
+        BlueprintReplacer.reset();
         VanillaReplacer.doReplacement(biomeRegistry, stemRegistry);
     }
     

--- a/src/main/java/net/werdei/biome_replacer/config/Config.java
+++ b/src/main/java/net/werdei/biome_replacer/config/Config.java
@@ -67,20 +67,13 @@ public class Config
                 if (isRestrictedBiome(oldBiome, lineCount)) continue;
                 if (isRestrictedBiome(newBiome, lineCount)) continue;
 
-                double probability = 1.0;
-                if (newBiomeWithProbability.length > 1) try
+                if (newBiomeWithProbability.length > 1)
                 {
-                    logRuleWarning(lineCount, "Chance-based replacement was removed from the mod (for now), probability will be ignored");
-                    probability = Double.parseDouble(newBiomeWithProbability[1].trim());
-//                    if (probability < 0.0 || probability > 1.0)
-//                        logRuleIssue(lineCount, "Probability will be clamped between 0 and 1");
-                }
-                catch (NumberFormatException e)
-                {
-//                    logRuleIssue(lineCount, "Unexpected number format. If you wanted to add probability, make sure it's a valid number");
+                    logRuleWarning(lineCount, "Chance-based replacement was removed from the mod (for now), ignoring rule");
+                    continue;
                 }
                 
-                rules.add(new Rule(lineCount, oldBiome, newBiome, probability, currentHeader));
+                rules.add(new Rule(lineCount, oldBiome, newBiome, 1.0, currentHeader));
             }
         }
         catch (IOException e)

--- a/src/main/java/net/werdei/biome_replacer/mixin/WorldStemMixin.java
+++ b/src/main/java/net/werdei/biome_replacer/mixin/WorldStemMixin.java
@@ -3,6 +3,9 @@ package net.werdei.biome_replacer.mixin;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.WorldStem;
 import net.minecraft.server.packs.resources.CloseableResourceManager;
+//? if unobfuscated
+/*import net.minecraft.world.level.storage.LevelDataAndDimensions;
+*///? if !unobfuscated
 import net.minecraft.world.level.storage.WorldData;
 import net.werdei.biome_replacer.BiomeReplacer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,7 +24,15 @@ import net.minecraft.core.RegistryAccess;
 @Mixin(WorldStem.class)
 public abstract class WorldStemMixin
 {
-    //? if >=1.19.3 {
+    //? if unobfuscated {
+    /*@Inject(method = "<init>", at = @At("TAIL"))
+    private void onStemCreated(CloseableResourceManager closeableResourceManager, ReloadableServerResources reloadableServerResources, LayeredRegistryAccess<RegistryLayer> layeredRegistryAccess, LevelDataAndDimensions.WorldDataAndGenSettings worldData, CallbackInfo ci)
+    {
+        var registryAccess = layeredRegistryAccess.compositeAccess();
+        BiomeReplacer.doReplacement(registryAccess.lookupOrThrow(Registries.BIOME), registryAccess.lookupOrThrow(Registries.LEVEL_STEM));
+    }
+
+    *///?} else if >=1.19.3 {
     @Inject(method = "<init>", at = @At("TAIL"))
     private void onStemCreated(CloseableResourceManager closeableResourceManager, ReloadableServerResources reloadableServerResources, LayeredRegistryAccess<RegistryLayer> layeredRegistryAccess, WorldData worldData, CallbackInfo ci)
     {

--- a/src/main/java/net/werdei/biome_replacer/replacer/BlueprintReplacer.java
+++ b/src/main/java/net/werdei/biome_replacer/replacer/BlueprintReplacer.java
@@ -26,6 +26,12 @@ public final class BlueprintReplacer
 
     private BlueprintReplacer() {}
 
+    // Drop biome sources left over from the previous world.
+    public static void reset()
+    {
+        DIMENSION_BY_SOURCE.clear();
+    }
+
     public static void pushDimensionContext(String dimensionId)
     {
         if (dimensionId == null || dimensionId.isEmpty())

--- a/src/main/java/net/werdei/biome_replacer/replacer/VanillaReplacer.java
+++ b/src/main/java/net/werdei/biome_replacer/replacer/VanillaReplacer.java
@@ -25,23 +25,25 @@ import static net.werdei.biome_replacer.BiomeReplacer.log;
 
 public class VanillaReplacer
 {
-    private static Map<Holder<Biome>, Holder<Biome>> replacementRules;
-    private static Map<String, Map<Holder<Biome>, Holder<Biome>>> dimensionReplacementRules;
-    
+    private static Map<Holder<Biome>, Holder<Biome>> replacementRules = Map.of();
+    private static Map<String, Map<Holder<Biome>, Holder<Biome>>> dimensionReplacementRules = Map.of();
+    // Used by Blueprint to avoid merging rules for every biome lookup.
+    private static Map<String, Map<Holder<Biome>, Holder<Biome>>> mergedDimensionRules = Map.of();
+
     public static void doReplacement(Registry<Biome> biomeRegistry, Registry<LevelStem> stemRegistry)
     {
-        PrepareRules(biomeRegistry);
-        if (replacementRules.isEmpty() && (dimensionReplacementRules == null || dimensionReplacementRules.isEmpty()))
+        prepareRules(biomeRegistry);
+        if (replacementRules.isEmpty() && dimensionReplacementRules.isEmpty())
         {
             BiomeReplacer.log("No rules found, not replacing anything");
             return;
         }
-        
+
         var knownDimensions = new HashSet<String>();
         for (var entry : stemRegistry.entrySet())
             knownDimensions.add(entry.getKey().location().toString());
-        
-        if (dimensionReplacementRules != null && !dimensionReplacementRules.isEmpty())
+
+        if (!dimensionReplacementRules.isEmpty())
         {
             Map<String, List<Integer>> ruleLinesByDimension = new HashMap<>();
             for (var rule : Config.rules)
@@ -78,48 +80,58 @@ public class VanillaReplacer
                 continue;
             }
             
+            var effectiveRules = mergedDimensionRules.getOrDefault(levelId.toString(), replacementRules);
+            if (effectiveRules.isEmpty())
+            {
+                BiomeReplacer.log("No rules apply to " + levelId + ", leaving it untouched");
+                continue;
+            }
+
             var biomeSource = (MultiNoiseBiomeSourceAccessor) generator.getBiomeSource();
-            
+
             //? if >=1.19.4
             var parameters = biomeSource.getParameters().map((p) -> p, (holder) -> holder.value().parameters());
             //? if <1.19.4
             /*var parameters = biomeSource.getParameters();*/
-            
+
             List<Pair<Climate.ParameterPoint, Holder<Biome>>> newParameterList = new ArrayList<>();
-            
-            Map<Holder<Biome>, Holder<Biome>> effectiveRules;
-            {
-                var merged = new HashMap<Holder<Biome>, Holder<Biome>>();
-                if (replacementRules != null && !replacementRules.isEmpty())
-                    merged.putAll(replacementRules);
-                var dimOverlay = (dimensionReplacementRules != null)
-                        ? dimensionReplacementRules.get(levelId.toString())
-                        : null;
-                if (dimOverlay != null && !dimOverlay.isEmpty())
-                    merged.putAll(dimOverlay);
-                effectiveRules = merged;
-            }
+            var changed = false;
+
             for (var value : parameters.values())
             {
                 var newBiome = replaceFromMap(value.getSecond(), effectiveRules);
+                if (newBiome != value.getSecond())
+                    changed = true;
                 if (newBiome == null) continue;
                 newParameterList.add(new Pair<>(value.getFirst(), newBiome));
             }
-            
+
+            // Don't replace parameter lists when no rules matched.
+            if (!changed)
+            {
+                BiomeReplacer.log("No rules matched any biomes in " + levelId + ", leaving it untouched");
+                continue;
+            }
+            if (newParameterList.isEmpty())
+            {
+                BiomeReplacer.logWarn("Rules would remove every biome in " + levelId + ", which is not possible. Leaving it untouched");
+                continue;
+            }
+
             //? if >=1.19.4
             biomeSource.setParameters(Either.left(new Climate.ParameterList<>(newParameterList)));
             //? if <1.19.4
             /*biomeSource.setParameters(new Climate.ParameterList<>(newParameterList));*/
-            
+
             BiomeReplacer.log("Successfully replaced biomes in " + levelId);
-            
+
         }
     }
-    
-    private static void PrepareRules(Registry<Biome> biomeRegistry)
+
+    private static void prepareRules(Registry<Biome> biomeRegistry)
     {
-        replacementRules = new HashMap<>();
-        dimensionReplacementRules = new HashMap<>();
+        var globalRules = new HashMap<Holder<Biome>, Holder<Biome>>();
+        var perDimensionRules = new HashMap<String, Map<Holder<Biome>, Holder<Biome>>>();
         var rulesDirect = 0;
         var rulesTag = 0;
         var rulesIgnored = 0;
@@ -127,16 +139,17 @@ public class VanillaReplacer
         for (var rule : Config.rules) try
         {
             Map<Holder<Biome>, Holder<Biome>> targetMap = rule.dimension() == null
-                    ? replacementRules
-                    : dimensionReplacementRules.computeIfAbsent(rule.dimension(), k -> new HashMap<>());
+                    ? globalRules
+                    : perDimensionRules.computeIfAbsent(rule.dimension(), k -> new HashMap<>());
             if (rule.from().startsWith("#"))
             {
                 var tagKey = getBiomeTagKey(rule.from().substring(1));
                 var newBiome = getBiomeHolder(rule.to(), biomeRegistry);
                 // Unwrapping the biome key and adding all biomes from it.
-                // Using "putIfAbsent" to make sure direct rules have priority
+                // Direct rules have priority. containsKey also preserves null removal rules.
                 for (var oldBiome : biomeRegistry.getTagOrEmpty(tagKey))
-                    targetMap.putIfAbsent(oldBiome, newBiome);
+                    if (!targetMap.containsKey(oldBiome))
+                        targetMap.put(oldBiome, newBiome);
                 rulesTag++;
             }
             else
@@ -152,7 +165,20 @@ public class VanillaReplacer
             BiomeReplacer.logRuleWarning(rule.line(), e.getMessage() + ", ignoring rule");
             rulesIgnored++;
         }
-        
+
+        // Cache merged rules for Blueprint's biome lookup.
+        var merged = new HashMap<String, Map<Holder<Biome>, Holder<Biome>>>();
+        for (var entry : perDimensionRules.entrySet())
+        {
+            var dimensionMerged = new HashMap<>(globalRules);
+            dimensionMerged.putAll(entry.getValue());
+            merged.put(entry.getKey(), dimensionMerged);
+        }
+
+        replacementRules = globalRules;
+        dimensionReplacementRules = perDimensionRules;
+        mergedDimensionRules = merged;
+
         log(String.format("Loaded %d rules (%d direct, %d tag-based) and ignored %d",
                 rulesDirect + rulesTag, rulesDirect, rulesTag, rulesIgnored));
     }
@@ -202,19 +228,13 @@ public class VanillaReplacer
 
     public static Holder<Biome> replaceIfNeeded(Holder<Biome> original, String dimensionId)
     {
-        if (dimensionId == null || dimensionReplacementRules == null || dimensionReplacementRules.isEmpty())
-            return replaceFromMap(original, replacementRules);
-
-        var dimensionRules = dimensionReplacementRules.get(dimensionId);
-        if (dimensionRules == null || dimensionRules.isEmpty())
-            return replaceFromMap(original, replacementRules);
-
-        if (replacementRules == null || replacementRules.isEmpty())
-            return replaceFromMap(original, dimensionRules);
-
-        var merged = new HashMap<Holder<Biome>, Holder<Biome>>(replacementRules);
-        merged.putAll(dimensionRules);
-        return replaceFromMap(original, merged);
+        if (dimensionId != null)
+        {
+            var dimensionRules = mergedDimensionRules.get(dimensionId);
+            if (dimensionRules != null)
+                return replaceFromMap(original, dimensionRules);
+        }
+        return replaceFromMap(original, replacementRules);
     }
     
     private static Holder<Biome> replaceFromMap(Holder<Biome> original, Map<Holder<Biome>, Holder<Biome>> rules)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,7 @@
 		"${id}.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.16",
+		"fabricloader": "${fabricLoader}",
 		"minecraft": "${minecraft}"
 	},
 	"custom": {

--- a/unobfuscated.gradle.kts
+++ b/unobfuscated.gradle.kts
@@ -1,0 +1,171 @@
+import net.fabricmc.loom.api.LoomGradleExtensionAPI
+import net.neoforged.moddevgradle.dsl.NeoForgeExtension
+import org.gradle.api.tasks.bundling.Jar
+
+plugins {
+	id("net.fabricmc.fabric-loom") version "1.17.0-alpha.19" apply false
+	id("net.neoforged.moddev") version "2.0.141" apply false
+	id("me.modmuss50.mod-publish-plugin") version "1.1.0"
+}
+
+val loader = property("loom.platform").toString()
+val isFabric = loader == "fabric"
+val isNeoforge = loader == "neoforge"
+val mcVersion = stonecutter.current.version
+val modId = property("mod.id").toString()
+val modName = property("mod.name")
+val modVersion = property("mod.version").toString()
+val modCodename = property("mod.mc_codename").toString()
+val modDescription = property("mod.description")
+val modSource = property("mod.source")
+val modIssues = property("mod.issues")
+val modLicense = property("mod.license")
+val modrinthId = property("mod.modrinth")
+val mcDependency = property("mod.mc_dep")
+val fabricLoader = property("deps.fabric_loader")
+val mcTargets = property("mod.mc_targets").toString().split(", ")
+val mixinSquared = property("deps.mixinsquared")
+
+when {
+	isFabric -> apply(plugin = "net.fabricmc.fabric-loom")
+	isNeoforge -> apply(plugin = "net.neoforged.moddev")
+	else -> throw GradleException("Unknown loader: $loader")
+}
+
+version = "$modVersion-$modCodename-${if (isNeoforge) "neo" else loader}"
+group = property("mod.group").toString()
+base { archivesName.set(modId.replace("_", "")) }
+
+stonecutter {
+	constants["fabric"] = isFabric
+	constants["neoforge"] = isNeoforge
+	constants["oldforge"] = false
+	constants["forge-like"] = isNeoforge
+	constants["unobfuscated"] = true
+
+	replacements.string(current.parsed >= "1.21.11") {
+		replace("ResourceLocation", "Identifier")
+		replace(".location()", ".identifier()")
+	}
+}
+
+repositories {
+	maven("https://maven.terraformersmc.com")
+	maven("https://maven.nucleoid.xyz/")
+	maven("https://maven.neoforged.net/releases")
+	maven("https://maven.minecraftforge.net/")
+	maven("https://maven.bawnorton.com/releases")
+}
+
+if (isFabric) {
+	extensions.configure<LoomGradleExtensionAPI>("loom") {
+		mods {
+			register(modId) {
+				sourceSet(sourceSets.main.get())
+			}
+		}
+	}
+} else {
+	extensions.configure<NeoForgeExtension>("neoForge") {
+		setVersion(property("deps.neoforge").toString())
+		runs {
+			register("client") {
+				client()
+				gameDirectory.set(rootProject.layout.projectDirectory.dir("run"))
+			}
+			register("server") {
+				server()
+				gameDirectory.set(rootProject.layout.projectDirectory.dir("run"))
+			}
+		}
+		mods {
+			register(modId) {
+				sourceSet(sourceSets.main.get())
+			}
+		}
+	}
+}
+
+dependencies {
+	if (isFabric) {
+		add("minecraft", "com.mojang:minecraft:$mcVersion")
+		add("implementation", "net.fabricmc:fabric-loader:$fabricLoader")
+		add("implementation", "net.fabricmc.fabric-api:fabric-api:${property("deps.fabric_api")}")
+		add("annotationProcessor", "com.github.bawnorton.mixinsquared:mixinsquared-fabric:$mixinSquared")
+		add("implementation", "com.github.bawnorton.mixinsquared:mixinsquared-fabric:$mixinSquared")
+		add("include", "com.github.bawnorton.mixinsquared:mixinsquared-fabric:$mixinSquared")
+
+		if (property("deps.modmenu_version") != "[VERSIONED]")
+			add("runtimeOnly", "com.terraformersmc:modmenu:${property("deps.modmenu_version")}")
+	} else {
+		add("annotationProcessor", "com.github.bawnorton.mixinsquared:mixinsquared-common:$mixinSquared")
+		add("compileOnly", "com.github.bawnorton.mixinsquared:mixinsquared-common:$mixinSquared")
+		add("implementation", "com.github.bawnorton.mixinsquared:mixinsquared-neoforge:$mixinSquared")
+		add("jarJar", "com.github.bawnorton.mixinsquared:mixinsquared-neoforge:$mixinSquared")
+	}
+
+	optionalProp("deps.terrablender") {
+		val terraBlender = "com.github.glitchfiend:TerraBlender-$loader:$mcVersion-$it"
+		add(if (property("deps.terrablender_enabled").toString().toBoolean()) "implementation" else "compileOnly", terraBlender)
+	}
+}
+
+java {
+	toolchain.languageVersion = JavaLanguageVersion.of(25)
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
+}
+
+tasks.withType<JavaCompile>().configureEach {
+	options.release.set(25)
+}
+
+tasks.processResources {
+	val props = mutableMapOf<String, Any?>(
+		"id" to modId,
+		"name" to modName,
+		"version" to "$modVersion-$modCodename",
+		"minecraft" to mcDependency,
+		"fabricLoader" to ">=$fabricLoader",
+		"description" to modDescription,
+		"source" to modSource,
+		"issues" to modIssues,
+		"license" to modLicense,
+		"modrinth" to modrinthId
+	)
+	if (isNeoforge)
+		props["forgeConstraint"] = findProperty("modstoml.forge_constraint")
+
+	inputs.properties(props)
+	if (isFabric) {
+		filesMatching("fabric.mod.json") { expand(props) }
+		exclude("META-INF/mods.toml", "META-INF/neoforge.mods.toml", "pack.mcmeta", "logo.png")
+	} else {
+		filesMatching("META-INF/neoforge.mods.toml") { expand(props) }
+		exclude("fabric.mod.json", "META-INF/mods.toml", "pack.mcmeta", "icon.png")
+	}
+}
+
+publishMods {
+	file = tasks.named<Jar>("jar").get().archiveFile
+	displayName = "$modVersion ${loader.replaceFirstChar { it.titlecase() }} ${mcTargets.first()}-${mcTargets.last()}"
+	changelog = rootProject.file("CHANGELOG.md").readText()
+	type = BETA
+	modLoaders.add(loader)
+
+	modrinth {
+		projectId = project.property("publish.modrinth").toString()
+		accessToken = findProperty("modrinth_token").toString()
+		mcTargets.forEach(minecraftVersions::add)
+		projectDescription = rootProject.file("README.md").readText()
+	}
+
+	curseforge {
+		projectId = project.property("publish.curseforge").toString()
+		accessToken = findProperty("curseforge_token").toString()
+		mcTargets.forEach(minecraftVersions::add)
+	}
+}
+
+fun <T> optionalProp(property: String, block: (String) -> T?): T? =
+	findProperty(property)?.toString()?.takeUnless { it.isBlank() }?.let(block)

--- a/versions/26.1.2-fabric/gradle.properties
+++ b/versions/26.1.2-fabric/gradle.properties
@@ -1,0 +1,10 @@
+loom.platform=fabric
+
+mod.mc_dep=>=26.1 <26.2
+mod.mc_targets=26.1, 26.1.1, 26.1.2
+mod.mc_codename=newt
+
+deps.fabric_loader=0.19.3
+deps.modmenu_version=18.0.0-beta.1
+deps.fabric_api=0.150.0+26.1.2
+deps.terrablender=26.1.2.0.2

--- a/versions/26.1.2-neoforge/gradle.properties
+++ b/versions/26.1.2-neoforge/gradle.properties
@@ -1,0 +1,10 @@
+loom.platform=neoforge
+
+mod.mc_dep=>=26.1 <26.2
+mod.mc_targets=26.1, 26.1.1, 26.1.2
+mod.mc_codename=newt
+
+deps.neoforge=26.1.2.73
+deps.terrablender=26.1.2.0.2
+
+modstoml.forge_constraint=[26.1,26.2)


### PR DESCRIPTION
I added a separate 26.1+ build script because Minecraft 26.1 removed obfuscation/mappings, so the old shared Loom setup does not really work nicely for these versions anymore. I checked a few similar Stonecutter projects and they are doing the same kind of thing, so the main thing for future versions is that 26.1+ builds now go through `unobfuscated.gradle.kts`.

Also, while testing, I found a weird config edge case where if you had an old probability value in the config, you could end up not being able to rejoin or recreate worlds. Minecraft was rejecting the saved world data during NBT loading. Probability rules are now skipped completely instead of accidentally being applied as full replacements, but they still warn in the logs.

I tested Neoforge and Fabric 26.1.2, everything else still builds correctly and shouldn't be negatively effected from these changes.